### PR TITLE
Added support for producing clang compilation databases.

### DIFF
--- a/OSX.ycm_extra_conf.py
+++ b/OSX.ycm_extra_conf.py
@@ -1,41 +1,33 @@
-# This file is NOT licensed under the GPLv3, which is the license for the rest
-# of YouCompleteMe.
-#
-# Here's the license text for this file:
-#
-# This is free and unencumbered software released into the public domain.
-#
-# Anyone is free to copy, modify, publish, use, compile, sell, or
-# distribute this software, either in source code form or as a compiled
-# binary, for any purpose, commercial or non-commercial, and by any
-# means.
-#
-# In jurisdictions that recognize copyright laws, the author or authors
-# of this software dedicate any and all copyright interest in the
-# software to the public domain. We make this dedication for the benefit
-# of the public at large and to the detriment of our heirs and
-# successors. We intend this dedication to be an overt act of
-# relinquishment in perpetuity of all present and future rights to this
-# software under copyright law.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-#
-# For more information, please refer to <http://unlicense.org/>
+"""An example ycmd 'extra conf' file for mac osx.
+
+THIS IS JUST AN EXAMPLE FILE! To use this you'll generally need to
+copy it to .ycm_extra_conf.py and edit it for your specific system.
+
+ycmd is a completion framework for various editors/IDEs. For more
+information, see https://github.com/Valloric/ycmd.
+"""
 
 import os
 import sys
 import ycm_core
 
+# These are includes that we have to specify explicitly because of
+# some defect in clang. These get added to flags specified in clang
+# compilation databases.
+include_flags = [
+    "-I/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1",
+    "-I/usr/local/include",
+    "-I/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/6.0/include",
+    "-I/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
+    "-I/usr/include",
+    "-I/System/Library/Frameworks",
+    "-I/Library/Frameworks",
+]
+
 # These are the compilation flags that will be used in case there's no
 # compilation database set (by default, one is not set).
 # CHANGE THIS LIST OF FLAGS. YES, THIS IS THE DROID YOU HAVE BEEN LOOKING FOR.
-flags = []
+flags = include_flags[:]
 
 # Set this to the absolute path to the folder (NOT the file!) containing the
 # compile_commands.json file to use that instead of 'flags'. See here for
@@ -111,7 +103,6 @@ def GetCompilationInfoForFile(filename):
             if os.path.exists(replacement_file):
                 compilation_info = database.GetCompilationInfoForFile(
                     replacement_file)
-                print('COMPILATION INFO:', compilation_info)
                 if compilation_info.compiler_flags_:
                     return compilation_info
         return None
@@ -129,6 +120,8 @@ def FlagsForFile(filename, **kwargs):
         final_flags = MakeRelativePathsInFlagsAbsolute(
             compilation_info.compiler_flags_,
             compilation_info.compiler_working_dir_)
+
+        final_flags.extend(include_flags)
 
         # NOTE: This is just for YouCompleteMe; it's highly likely
         # that your project does NOT need to remove the stdlib

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,21 @@ After that, the standard waf commands are all you need::
 
 The build output will be in ``build_directory``.
 
+Creating a clang compilation database (optional)
+------------------------------------------------
+
+If you want to create a clang compilation database as part of the
+build, you need to also update the `clang_compilation_database` tool::
+
+    % python waf update --files=clang_compilation_database
+
+Do this before running ``python waf configure``. After you've
+installed this tool, the build will generate a database in
+``build_directory/compile_commands.json``.
+
+Note that this tool is completely optional. If you don't install it,
+the build will work perfectly normally.
+
 Running tests
 =============
 

--- a/wscript
+++ b/wscript
@@ -1,6 +1,7 @@
 import os
-import subprocess
 import sys
+
+import waflib.Errors
 
 top = '.'
 out = 'build_directory'
@@ -19,8 +20,21 @@ def options(opt):
               'safely ignore it.')
 
 
+def load_if_exists(conf, tool):
+    """Try to load a tool, but ignore errors if it doesn't exist.
+
+    This is for e.g. loading optional tools, the absence of which
+    won't impact the correctness of the build.
+    """
+    try:
+        conf.load(tool)
+    except waflib.Errors.ConfigurationError:
+        print('Extra tool "{}" not found. Ignoring.'.format(tool))
+
+
 def configure(conf):
     conf.load('compiler_cxx boost python')
+    load_if_exists(conf, 'clang_compilation_database')
     conf.check_python_headers()
 
     # On some systems, boost_python does not link against python


### PR DESCRIPTION
This is useful for using tools like ycmd. The intention is that this patch won't impact anyone who doesn't care about creating clang compilation databases. I use these databases for C++ completion via ycmd in emacs, so it's convenient for me to include these changes in the repository.
